### PR TITLE
Apply border to ext:focuspoint images as well

### DIFF
--- a/Resources/Public/Css/Frontend/focuspoint.css
+++ b/Resources/Public/Css/Frontend/focuspoint.css
@@ -41,6 +41,7 @@
 	grid-row: 1 / 2;
 	max-width: 100%;
 	height: auto;
+	border: 1px solid darkgrey;
 }
 
 .focuspoint__svg {

--- a/Resources/Public/Css/Frontend/manual.css
+++ b/Resources/Public/Css/Frontend/manual.css
@@ -117,7 +117,7 @@ figure {
 	margin: 0.25rem 0;
 }
 
-figure.image {
+figure.image img {
 	border: 1px solid darkgrey;
 }
 


### PR DESCRIPTION
Screenshots with white background look odd in a manual with white background. Therefore a light grey border is applied to all images already. This followup commit applies the same border to all images in the preconfigured focuspoint extension.