### PR TITLE
Hide workspace badge in frontend preview as well

### DIFF
--- a/Resources/Public/Css/Frontend/manual.css
+++ b/Resources/Public/Css/Frontend/manual.css
@@ -140,6 +140,14 @@ figcaption {
 	order: 1;
 }
 
+/* Hide unnecessary TYPO3 workspace overlays in manual */
+#typo3-preview-info {
+  display: none;
+}
+
+/**
+	Media type adjustments
+ */
 @media (min-width: 800px) {
 	.ce-image.ce-right, .ce-image.ce-left {
 		grid-template-columns: 1fr 1fr;


### PR DESCRIPTION
When the manual is opened with a direct link (example.com/manual) yet another TYPO3 workspace badge is shown. 😬
Hide this as well. Thats the last one certainly.